### PR TITLE
Use Hoare partitioning algorithm for quickselect

### DIFF
--- a/src/quickselect.rs
+++ b/src/quickselect.rs
@@ -27,21 +27,26 @@ pub fn select<T: Ord>(x: &mut [T], k: usize) {
 }
 
 fn partition<T: Ord>(x: &mut [T]) -> usize {
-    let l = x.len();
-    let mut store = 0;
-    {
-        let (y, elem) = x.split_at_mut(l - 1);
-        let elem = &mut elem[0];
-
-        for load in 0..l - 1 {
-            if y[load] < *elem {
-                y.swap(load, store);
-                store += 1
-            }
+    let mut a = 1;
+    let mut b = x.len() - 1;
+    
+    'outer: loop {
+        loop {
+            if a > b { break 'outer; }
+            if x[a] >= x[0] { break; }
+            a += 1;
         }
+        while x[0] < x[b] {
+            b -= 1;
+        }
+        if a >= b { break; }
+        
+        x.swap(a, b);
+        a += 1;
+        b -= 1;
     }
-    x.swap(store, l - 1);
-    store
+    x.swap(0, a - 1);
+    a - 1
 }
 
 #[cfg(test)]


### PR DESCRIPTION
[This paper](https://arxiv.org/pdf/1606.00484v1.pdf) by Andrei Alexandrescu has a supposedly faster algorithm for finding order stats. I didn't get so far as implementing it, but did notice it had a faster implementation of Median of Medians.