### PR TITLE
Miri: reference-aliasing bugfix

### DIFF
--- a/src/floyd_rivest.rs
+++ b/src/floyd_rivest.rs
@@ -16,7 +16,6 @@ fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize
 where
     F: FnMut(&T, &T) -> Ordering,
 {
-    let array = array;
     while right > left {
         if right - left > A {
             let n = (right - left + 1) as f32;

--- a/src/floyd_rivest.rs
+++ b/src/floyd_rivest.rs
@@ -1,9 +1,9 @@
-use std::cmp::Ordering;
+use std::cmp::Ordering::{self, Greater, Less};
 use std::{cmp, ptr};
 
 pub fn select<T, F>(array: &mut [T], k: usize, mut f: F)
 where
-    F: FnMut(&T, &T) -> cmp::Ordering,
+    F: FnMut(&T, &T) -> Ordering,
 {
     let r = array.len() - 1;
     select_(array, &mut f, 0, r, k)
@@ -14,7 +14,7 @@ const B: f32 = 0.5;
 
 fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize, k: usize)
 where
-    F: FnMut(&T, &T) -> cmp::Ordering,
+    F: FnMut(&T, &T) -> Ordering,
 {
     let array = array;
     while right > left {
@@ -37,7 +37,7 @@ where
         let mut i = left + 1;
         let mut j = right - 1;
         array.swap(left, k);
-        let t_idx = if cmp(&array[left], &array[right]) != cmp::Ordering::Less {
+        let t_idx = if cmp(&array[left], &array[right]) != Less {
             array.swap(left, right);
             right
         } else {
@@ -52,10 +52,10 @@ where
         // We can be extra sure that we don't borrow `array` here.
         let t = unsafe { &*arr_ptr.add(t_idx) };
         unsafe {
-            while cmp(&*arr_ptr.add(i), t) == Ordering::Less {
+            while cmp(&*arr_ptr.add(i), t) == Less {
                 i += 1
             }
-            while cmp(&*arr_ptr.add(j), t) == Ordering::Greater {
+            while cmp(&*arr_ptr.add(j), t) == Greater {
                 j -= 1
             }
         }
@@ -74,10 +74,10 @@ where
                     ptr::swap(arr_ptr.add(i), arr_ptr.add(j));
                     i += 1;
                     j -= 1;
-                    while cmp(&*arr_ptr.add(i), t) == Ordering::Less {
+                    while cmp(&*arr_ptr.add(i), t) == Less {
                         i += 1
                     }
-                    while cmp(&*arr_ptr.add(j), t) == Ordering::Greater {
+                    while cmp(&*arr_ptr.add(j), t) == Greater {
                         j -= 1
                     }
                 }
@@ -101,9 +101,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::select;
     use quickcheck::{self, TestResult};
     use rand::{Rng, XorShiftRng};
+
+    use super::select;
 
     #[test]
     fn qc() {

--- a/src/floyd_rivest.rs
+++ b/src/floyd_rivest.rs
@@ -1,8 +1,9 @@
-use std::{cmp, ptr};
 use std::cmp::Ordering;
+use std::{cmp, ptr};
 
 pub fn select<T, F>(array: &mut [T], k: usize, mut f: F)
-    where F: FnMut(&T, &T) -> cmp::Ordering
+where
+    F: FnMut(&T, &T) -> cmp::Ordering,
 {
     let r = array.len() - 1;
     select_(array, &mut f, 0, r, k)
@@ -12,7 +13,8 @@ const A: usize = 600;
 const B: f32 = 0.5;
 
 fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize, k: usize)
-    where F: FnMut(&T, &T) -> cmp::Ordering
+where
+    F: FnMut(&T, &T) -> cmp::Ordering,
 {
     let array = array;
     while right > left {
@@ -50,8 +52,12 @@ fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize
         // We can be extra sure that we don't borrow `array` here.
         let t = unsafe { &*arr_ptr.add(t_idx) };
         unsafe {
-            while cmp(&*arr_ptr.add(i), t) == Ordering::Less { i += 1 }
-            while cmp(&*arr_ptr.add(j), t) == Ordering::Greater { j -= 1 }
+            while cmp(&*arr_ptr.add(i), t) == Ordering::Less {
+                i += 1
+            }
+            while cmp(&*arr_ptr.add(j), t) == Ordering::Greater {
+                j -= 1
+            }
         }
 
         if i < j {
@@ -68,8 +74,12 @@ fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize
                     ptr::swap(arr_ptr.add(i), arr_ptr.add(j));
                     i += 1;
                     j -= 1;
-                    while cmp(&*arr_ptr.add(i), t) == Ordering::Less { i += 1 }
-                    while cmp(&*arr_ptr.add(j), t) == Ordering::Greater { j -= 1 }
+                    while cmp(&*arr_ptr.add(i), t) == Ordering::Less {
+                        i += 1
+                    }
+                    while cmp(&*arr_ptr.add(j), t) == Ordering::Greater {
+                        j -= 1
+                    }
                 }
             }
         }
@@ -80,8 +90,12 @@ fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize
             j += 1;
             array.swap(right, j);
         }
-        if j <= k { left = j + 1 }
-        if k <= j { right = j.saturating_sub(1); }
+        if j <= k {
+            left = j + 1
+        }
+        if k <= j {
+            right = j.saturating_sub(1);
+        }
     }
 }
 
@@ -89,7 +103,7 @@ fn select_<T, F>(array: &mut [T], cmp: &mut F, mut left: usize, mut right: usize
 mod tests {
     use super::select;
     use quickcheck::{self, TestResult};
-    use rand::{XorShiftRng, Rng};
+    use rand::{Rng, XorShiftRng};
 
     #[test]
     fn qc() {
@@ -114,6 +128,7 @@ mod tests {
             assert_eq!(array[k], k);
         }
     }
+
     #[test]
     fn huge() {
         let mut rng = XorShiftRng::new_unseeded();


### PR DESCRIPTION
This patch amounts to a bugfix for aliased references in the unsafe sections in the floyd-rivest algorithm, discovered by running Miri against a usage of this crate (this is in the first commit). Also included are minor formatting and cleanups in that file, able to be removed if you have any strong opinions (in the following two commits).

Before this PR:
```
$ cargo miri test
[...]
running 10 tests
test floyd_rivest::tests::huge ... error: Undefined Behavior: attempting a read access using <333853> at alloc115940[0x4250], but that tag does not exist in the borrow stack for this location
   --> /home/widders/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:860:9
    |
860 |         copy_nonoverlapping(x, tmp.as_mut_ptr(), 1);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         |
    |         attempting a read access using <333853> at alloc115940[0x4250], but that tag does not exist in the borrow stack for this location
    |         this error occurs as part of an access at alloc115940[0x4250..0x4254]
[...]
```
After this PR:
```
$ cargo miri test
[...]
running 10 tests
test floyd_rivest::tests::huge ... ok
test floyd_rivest::tests::qc ... ok
test floyd_rivest::tests::smoke ... ok
test mom::tests::correct_sortings ... ok
test mom::tests::include_trailing ... ok
test mom::tests::qc ... ok
test mom::tests::smoke ... ok
test quickselect::tests::huge ... ok
test quickselect::tests::qc ... ok
test quickselect::tests::smoke ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests order-stat

running 12 tests
test src/lib.rs - kth (line 103) ... ok
test src/lib.rs - kth (line 137) ... ok
test src/lib.rs - kth_by (line 182) ... ok
test src/lib.rs - kth (line 147) ... ok
test src/lib.rs - (line 54) ... ok
test src/lib.rs - (line 23) ... ok
test src/lib.rs - (line 71) ... ok
test src/mom.rs - mom::median_of_medians_by (line 45) ... ok
test src/lib.rs - (line 34) ... ok
test src/lib.rs - (line 41) ... ok
test src/lib.rs - (line 64) ... ok
test src/mom.rs - mom::median_of_medians (line 19) ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
```

The root problem seems to be that writing `array.get_unchecked_mut(i)`, or `&*array.(...)`, causes a mutable borrow of all of `array` that conflicts with the immutable borrow also taken by `&*t`. Or, as I'm seeing in this error message, fetching the pointers for indexes `i` and `j` may require mutable borrows that conflict with *each other*, inside in the arguments of `ptr::swap()`.